### PR TITLE
Limited Newsletter Image Sizes for Better Display on Mobile Screens

### DIFF
--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -53,7 +53,7 @@ const serializers: Partial<PortableTextReactComponents> = {
                     alt={value.alt || "Image"}
                     width={600}
                     height={400}
-                    className="rounded-lg"
+                    className="rounded-lg w-full max-w-[95%] mx-auto"
                 />
             </div>
         ),


### PR DESCRIPTION
feature/MB-38-Newsletters-with-very-large-images-are-displaying-out-of-view-on-mobile