### PR TITLE
MB-40 Fix Icon Size on Mobile Too Small

### DIFF
--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -52,7 +52,7 @@ const NewslettersGridSection = async () => {
               <Card
                 title={newsletter.title}
                 description={newsletter.description}
-                icon={<Icons.MdArticle className="w-full h-fit" />}
+                icon={<Icons.MdArticle className="w-full h-fit text-2xl" />}
               />
             </Link>
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ const AboutUsSection = async () => {
                 key={card._key}
                 title={card.title}
                 description={card.description}
-                icon={<IconComponent className="w-full h-fit" />}
+                icon={<IconComponent className="w-full h-fit text-2xl" />}
                 image={{
                   src: urlFor(card.image.asset).url(),
                   alt: `${card.title}`,
@@ -79,7 +79,7 @@ const AboutUsSection = async () => {
               />
             );
           })}
-        <Card title="Sponsors" icon={<Icons.MdStar className="w-full h-fit" />}>
+        <Card title="Sponsors" icon={<Icons.MdStar className="w-full h-fit text-2xl" />}>
           {sponsors && sponsors.length > 0 && (
             <div className="flex items-center justify-center h-full">
               <Ticker>
@@ -131,7 +131,7 @@ const NewslettersSection = async () => {
             <Card
               title={newsletter.title}
               description={newsletter.description}
-              icon={<Icons.MdArticle className="w-full h-fit"/>}
+              icon={<Icons.MdArticle className="w-full h-fit text-2xl"/>}
             />
           </Link>
         ))}
@@ -163,7 +163,7 @@ const TeamSection: FC = async () => {
                 <div className="flex w-full h-fit text-start md:justify-between flex-col md:flex-row gap-y-6 p-6">
                   <div className="flex flex-row items-center gap-x-2">
                     <div className="w-6">
-                      <IconComponent className="w-full h-fit" />
+                      <IconComponent className="w-full h-fit text-2xl" />
                     </div>
                     <span className="text-white-00">{teamItem.name}</span>
                   </div>
@@ -186,7 +186,7 @@ const TeamSection: FC = async () => {
                 <div className="flex flex-col w-full h-fit text-start gap-y-6 p-6">
                   <div className="flex flex-row items-center gap-x-2">
                     <div className="w-6">
-                      <IconComponent className="w-full h-fit" />
+                      <IconComponent className="w-full h-fit text-2xl" />
                     </div>
                     <span className="text-white-00">{teamItem.name}</span>
                   </div>
@@ -210,7 +210,7 @@ const TeamSection: FC = async () => {
                                     height={150}
                                   />
                                   :
-                                  <Icons.MdCode size={200} />
+                                  <Icons.MdCode size={200} className="text-2xl" />
                                 }
                               </div>
                             </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ const AboutUsSection = async () => {
                 key={card._key}
                 title={card.title}
                 description={card.description}
-                icon={<IconComponent className="w-full h-fit text-2xl" />}
+                icon={<IconComponent className="text-2xl" />}
                 image={{
                   src: urlFor(card.image.asset).url(),
                   alt: `${card.title}`,
@@ -131,7 +131,7 @@ const NewslettersSection = async () => {
             <Card
               title={newsletter.title}
               description={newsletter.description}
-              icon={<Icons.MdArticle className="w-full h-fit text-2xl"/>}
+              icon={<Icons.MdArticle className="text-2xl"/>}
             />
           </Link>
         ))}
@@ -162,9 +162,7 @@ const TeamSection: FC = async () => {
               <Card key={index} className={colSpanClass}>
                 <div className="flex w-full h-fit text-start md:justify-between flex-col md:flex-row gap-y-6 p-6">
                   <div className="flex flex-row items-center gap-x-2">
-                    <div className="w-6">
-                      <IconComponent className="w-full h-fit text-2xl" />
-                    </div>
+                    <IconComponent className="text-2xl" />
                     <span className="text-white-00">{teamItem.name}</span>
                   </div>
                   {!hasProjects &&
@@ -185,9 +183,7 @@ const TeamSection: FC = async () => {
               <Card>
                 <div className="flex flex-col w-full h-fit text-start gap-y-6 p-6">
                   <div className="flex flex-row items-center gap-x-2">
-                    <div className="w-6">
-                      <IconComponent className="w-full h-fit text-2xl" />
-                    </div>
+                    <IconComponent className="text-2xl" />
                     <span className="text-white-00">{teamItem.name}</span>
                   </div>
                   {!hasProjects && 


### PR DESCRIPTION
Increased icon size by applying `font-size`. Let me know if you want the size larger/smaller

![image](https://github.com/user-attachments/assets/1f3af9dc-31e3-45a6-b711-ff2b6b6ba736)

Unfortunately, this method didn't seem to apply for any of the icons under "Our Team", which is weird, since the icon seems to be applied the exact same way. I tried adjusting the parent container, but it was no use

![image](https://github.com/user-attachments/assets/c38bc157-6df5-407b-91f1-7a020d48a087)
