### PR TITLE
Mb 63 add an agenda section to the event details page listing the itinerary for a given event

### DIFF
--- a/app/components/EventAgenda.tsx
+++ b/app/components/EventAgenda.tsx
@@ -59,7 +59,6 @@ export default function EventAgenda({ agenda }: EventAgendaProps) {
             key={index} 
             className={`space-y-4 ${selectedIndex === index ? 'block' : 'hidden'}`}
           >
-            <h3 className="text-xl font-extrabold">{agendaDay.title}</h3>
             <ul className="space-y-6">
               {agendaDay.agenda.map((item: AgendaItem, innerIndex: number) => (
                 <li key={innerIndex} className="flex flex-col gap-3 p-4 rounded-lg bg-gray-50 dark:bg-gray-800">

--- a/app/components/EventAgenda.tsx
+++ b/app/components/EventAgenda.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { TfiAgenda } from "react-icons/tfi";
+import SectionCard from "./SectionCard";
+
+interface AgendaData {
+  title: string,
+  agenda: Array<AgendaItem>,
+}
+
+interface AgendaItem {
+  time: string,
+  activity: string,
+  description: string,
+  audience_type: string,
+}
+
+interface EventAgendaProps {
+  agenda: {
+    days: AgendaData[];
+    empty: boolean;
+  };
+}
+
+export default function EventAgenda({ agenda }: EventAgendaProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  if (agenda.empty) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Event Agenda" description="" id={"event-details-agenda-section"}>
+      <div className="flex flex-row items-center gap-4 mb-8">
+        <div className="p-3 bg-blue-400 text-white rounded-full shrink-0">
+          <TfiAgenda size={32}/>
+        </div>
+        <div className="flex-1">
+          <ul className="flex flex-row gap-6 overflow-x-auto pb-2">
+            {agenda.days.map((agendaDay: AgendaData, index: number) => (
+              <li 
+                key={index} 
+                className={`text-lg font-semibold whitespace-nowrap cursor-pointer ${
+                  selectedIndex === index ? 'text-blue-400' : ''
+                }`}
+                onClick={() => setSelectedIndex(index)}
+              >
+                {agendaDay.title}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {agenda.days.map((agendaDay: AgendaData, index: number) => (
+          <div 
+            key={index} 
+            className={`space-y-4 ${selectedIndex === index ? 'block' : 'hidden'}`}
+          >
+            <h3 className="text-xl font-extrabold">{agendaDay.title}</h3>
+            <ul className="space-y-6">
+              {agendaDay.agenda.map((item: AgendaItem, innerIndex: number) => (
+                <li key={innerIndex} className="flex flex-col gap-3 p-4 rounded-lg bg-gray-50 dark:bg-gray-800">
+                  <div className="flex items-center gap-3">
+                    <span className="font-bold text-lg">{item.activity}</span>
+                    <span className="text-gray-600 dark:text-gray-400 font-medium">{item.time}</span>
+                  </div>
+                  <p className="text-gray-700 dark:text-gray-300 text-base leading-relaxed">{item.description}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+} 

--- a/app/components/EventAgenda.tsx
+++ b/app/components/EventAgenda.tsx
@@ -41,7 +41,7 @@ export default function EventAgenda({ agenda }: EventAgendaProps) {
             {agenda.days.map((agendaDay: AgendaData, index: number) => (
               <li 
                 key={index} 
-                className={`text-lg font-semibold whitespace-nowrap cursor-pointer ${
+                className={`text-lg font-semibold hover:text-blue-400 whitespace-nowrap cursor-pointer ${
                   selectedIndex === index ? 'text-blue-400' : ''
                 }`}
                 onClick={() => setSelectedIndex(index)}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -32,8 +32,21 @@ interface Event {
     rsvp_only: boolean,
     url: string,
     completed: boolean,
+    agenda: string,
   }
 
+  interface AgendaData {
+    title: string,
+    agenda: Array<AgendaItem>,
+  }
+
+  interface AgendaItem {
+    time: string,
+    activity: string,
+    description: string,
+    audience_type: string,
+  }
+  
   const HeroSection = ({ title, start_date, end_date, rsvpCount }: { title: string, start_date: string, end_date: string, rsvpCount: number }) => {
     const formattedStartDate = formatDate(start_date);
     const formattedEndDate = formatDate(end_date);
@@ -79,19 +92,44 @@ interface Event {
 export default async function EventPage({ params }: { params: Promise<{ slug: string }> }) {
     const { slug } = await params;
     const { event_data }: { event_data: Event } = await getEvent(slug);
+    const parsedAgenda = JSON.parse(event_data.agenda);
+
+    console.log(parsedAgenda);
+    console.log(parsedAgenda.days[0].agenda);
+
     return (
       <>
         <Header/>
         <main>
           <HeroSection title={event_data.title} start_date={event_data.start_date_iso} end_date={event_data.end_date_iso} rsvpCount={event_data.total_attendees}/>
-          <SectionCard title="" description="" id={"event-details-section"}>
+          <SectionCard title="About This Event" description="" id={"event-details-section"}>
             <div>
               <Image width={2000} height={300} src={event_data.banner ? event_data.banner : event_data.chapter_banner} alt="Banner Image" className="w-auto h-auto rounded-lg mx-auto mb-20"></Image>
               {event_data.rsvp_only && !event_data.completed && <ChevronArrowButton className="dark:bg-white-00 bg-black-00 dark:text-black-00 text-white-00 border-2 dark:border-black-00 border-white-00 mb-10"><Link target="_blank" href={event_data.url}><span className="font-semibold text-2xl">RSVP</span></Link></ChevronArrowButton>}
-              <h2 className="font-bold mb-10">About This Event</h2>
               <div className="event-description" dangerouslySetInnerHTML={{ __html: event_data.description }} />
             </div>
           </SectionCard>
+          {!parsedAgenda.empty && <SectionCard title="Event Agenda" description="" id={"event-details-agenda-section"}>
+            <ul>
+              {parsedAgenda.days.map((agendaDay: AgendaData , index: number) => (
+                <li key={index}>
+                  <h3>{agendaDay.title}</h3>
+                  <ul>
+                    {agendaDay.agenda.map((item: AgendaItem, innerIndex: number) => (
+                      <li key={innerIndex}>
+                        <h4>{item.activity}</h4>
+                        <p>{item.time}</p>
+                        <p>{item.description}</p>
+
+                      </li>
+                    ))}
+                  </ul>
+
+                </li>
+              ))}
+            </ul>
+
+          </SectionCard>}
           <SectionCard title="" description="" id={"event-details-location-section"}>
             {event_data.venue_name  ? (<div className="flex flex-col sm:flex-row max-w-full justify-between items-start gap-4">
                                           <div className="flex-1 flex items-start gap-5 my-auto">

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,3 +1,4 @@
+
 import Header from "@/app/components/Header";
 import getEvent from '../../lib/getEvent';
 import AnimatedHero from "../../components/AnimatedHero";
@@ -11,6 +12,7 @@ import Map from '@/app/components/Map';
 import { FaLocationDot } from "react-icons/fa6";
 import Link from "next/link";
 import { ChevronArrowButton } from "@/app/components/ChevronArrow";
+import EventAgenda from "@/app/components/EventAgenda";
 
 interface Event {
     start_date_iso: string,
@@ -33,21 +35,9 @@ interface Event {
     url: string,
     completed: boolean,
     agenda: string,
-  }
+}
 
-  interface AgendaData {
-    title: string,
-    agenda: Array<AgendaItem>,
-  }
-
-  interface AgendaItem {
-    time: string,
-    activity: string,
-    description: string,
-    audience_type: string,
-  }
-  
-  const HeroSection = ({ title, start_date, end_date, rsvpCount }: { title: string, start_date: string, end_date: string, rsvpCount: number }) => {
+const HeroSection = ({ title, start_date, end_date, rsvpCount }: { title: string, start_date: string, end_date: string, rsvpCount: number }) => {
     const formattedStartDate = formatDate(start_date);
     const formattedEndDate = formatDate(end_date);
     let displayDate;
@@ -94,61 +84,67 @@ export default async function EventPage({ params }: { params: Promise<{ slug: st
     const { event_data }: { event_data: Event } = await getEvent(slug);
     const parsedAgenda = JSON.parse(event_data.agenda);
 
-    console.log(parsedAgenda);
-    console.log(parsedAgenda.days[0].agenda);
-
     return (
       <>
         <Header/>
         <main>
-          <HeroSection title={event_data.title} start_date={event_data.start_date_iso} end_date={event_data.end_date_iso} rsvpCount={event_data.total_attendees}/>
+          <HeroSection 
+            title={event_data.title} 
+            start_date={event_data.start_date_iso} 
+            end_date={event_data.end_date_iso} 
+            rsvpCount={event_data.total_attendees}
+          />
           <SectionCard title="About This Event" description="" id={"event-details-section"}>
             <div>
-              <Image width={2000} height={300} src={event_data.banner ? event_data.banner : event_data.chapter_banner} alt="Banner Image" className="w-auto h-auto rounded-lg mx-auto mb-20"></Image>
-              {event_data.rsvp_only && !event_data.completed && <ChevronArrowButton className="dark:bg-white-00 bg-black-00 dark:text-black-00 text-white-00 border-2 dark:border-black-00 border-white-00 mb-10"><Link target="_blank" href={event_data.url}><span className="font-semibold text-2xl">RSVP</span></Link></ChevronArrowButton>}
+              <Image 
+                width={2000} 
+                height={300} 
+                src={event_data.banner ? event_data.banner : event_data.chapter_banner} 
+                alt="Banner Image" 
+                className="w-auto h-auto rounded-lg mx-auto mb-20"
+              />
+              {event_data.rsvp_only && !event_data.completed && (
+                <ChevronArrowButton className="dark:bg-white-00 bg-black-00 dark:text-black-00 text-white-00 border-2 dark:border-black-00 border-white-00 mb-10">
+                  <Link target="_blank" href={event_data.url}>
+                    <span className="font-semibold text-2xl">RSVP</span>
+                  </Link>
+                </ChevronArrowButton>
+              )}
               <div className="event-description" dangerouslySetInnerHTML={{ __html: event_data.description }} />
             </div>
           </SectionCard>
-          {!parsedAgenda.empty && <SectionCard title="Event Agenda" description="" id={"event-details-agenda-section"}>
-            <ul>
-              {parsedAgenda.days.map((agendaDay: AgendaData , index: number) => (
-                <li key={index}>
-                  <h3>{agendaDay.title}</h3>
-                  <ul>
-                    {agendaDay.agenda.map((item: AgendaItem, innerIndex: number) => (
-                      <li key={innerIndex}>
-                        <h4>{item.activity}</h4>
-                        <p>{item.time}</p>
-                        <p>{item.description}</p>
-
-                      </li>
-                    ))}
-                  </ul>
-
-                </li>
-              ))}
-            </ul>
-
-          </SectionCard>}
+          <EventAgenda agenda={parsedAgenda} />
           <SectionCard title="" description="" id={"event-details-location-section"}>
-            {event_data.venue_name  ? (<div className="flex flex-col sm:flex-row max-w-full justify-between items-start gap-4">
-                                          <div className="flex-1 flex items-start gap-5 my-auto">
-                                              <div className="p-3 bg-blue-400 text-white rounded-full"><FaLocationDot size={32} /></div>
-                                              <div>
-                                                <h4 className="sm:text-4xl text-2xl font-bold">Location</h4>
-                                                <h5 className="sm:text-2xl text-l font-light">{event_data.venue_name}, {event_data.venue_address}, {event_data.venue_city}, {event_data.venue_zip_code}</h5>
-                                              </div>
-                                          </div>
-                                        <div className="flex-1 min-w-[200px] mx-auto"><Map address={event_data.venue_name.concat(", ", event_data.venue_address, ", ", event_data.venue_city, ", ON")} /></div>
-                                      </div>) : (event_data.is_virtual_event &&  
-                                                    <div className="flex flex-row max-w-full justify-between items-start gap-4">
-                                                      <div className="p-3 bg-blue-400 rounded-full"><FaLocationDot size={32} /></div>
-                                                      <div>
-                                                        <h4 className="sm:text-4xl text-2xl font-bold">Location</h4>
-                                                        <h5 className="sm:text-2xl text-l font-light">Virtual</h5>
-                                                      </div>
-                                                    </div>
-                                      )}
+            {event_data.venue_name ? (
+              <div className="flex flex-col sm:flex-row max-w-full justify-between items-start gap-4">
+                <div className="flex-1 flex items-start gap-5 my-auto">
+                  <div className="p-3 bg-blue-400 text-white rounded-full">
+                    <FaLocationDot size={32} />
+                  </div>
+                  <div>
+                    <h4 className="sm:text-4xl text-2xl font-bold">Location</h4>
+                    <h5 className="sm:text-2xl text-l font-light">
+                      {event_data.venue_name}, {event_data.venue_address}, {event_data.venue_city}, {event_data.venue_zip_code}
+                    </h5>
+                  </div>
+                </div>
+                <div className="flex-1 min-w-[200px] mx-auto">
+                  <Map 
+                    address={`${event_data.venue_name}, ${event_data.venue_address}, ${event_data.venue_city}, ON`} 
+                  />
+                </div>
+              </div>
+            ) : event_data.is_virtual_event && (
+              <div className="flex flex-row max-w-full justify-between items-start gap-4">
+                <div className="p-3 bg-blue-400 rounded-full">
+                  <FaLocationDot size={32} />
+                </div>
+                <div>
+                  <h4 className="sm:text-4xl text-2xl font-bold">Location</h4>
+                  <h5 className="sm:text-2xl text-l font-light">Virtual</h5>
+                </div>
+              </div>
+            )}
           </SectionCard>
         </main>
       </>


### PR DESCRIPTION
-This feature adds an agenda section to events that have a certain itinerary, listing each individual sub-event happening throughout the main event and the time it is at.
-Not all events have an agenda
-To see how this feature will look, click on the Mac-a-thon event or the Devfest event, as those are the only two returned by the api currently that have an agenda. I think this will look super cool for the site!